### PR TITLE
Refactor tests for OTP 21 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 elixir:
-  - 1.6.5
+  - 1.6.6
 otp_release:
-  - 20.0
+  - 21.0.1
 env:
   - MIX_ENV=test
 

--- a/integration/mix.exs
+++ b/integration/mix.exs
@@ -24,7 +24,7 @@ defmodule Integration.MixProject do
   defp deps do
     [
       {:jylis_ex, ">= 0.0.0", path: ".."},
-      {:espec,    "~> 1.5.1", only: :test},
+      {:espec,    "~> 1.6.0", only: :test},
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Jylis.MixProject do
     [
       {:poison,      "~> 3.1.0"},
       {:redix,       "~> 0.7.1"},
-      {:espec,       "~> 1.5.1",  only: :test},
+      {:espec,       "~> 1.6.0",  only: :test},
       {:excoveralls, "~> 0.8.2",  only: :test},
       {:ex_doc,      "~> 0.18.4", only: :dev, runtime: false},
       {:benchee,     "~> 0.13.1", only: :dev},

--- a/spec/data_types/gcount_spec.exs
+++ b/spec/data_types/gcount_spec.exs
@@ -6,7 +6,7 @@ defmodule Jylis.GCOUNT.Spec do
   let :value,      do: 50
 
   specify "get" do
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["GCOUNT", "GET", key()])
 
@@ -15,11 +15,11 @@ defmodule Jylis.GCOUNT.Spec do
 
     Jylis.GCOUNT.get(connection(), key()) |> should(eq {:ok, value()})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 
   specify "inc" do
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["GCOUNT", "INC", key(), value()])
 
@@ -28,6 +28,6 @@ defmodule Jylis.GCOUNT.Spec do
 
     Jylis.GCOUNT.inc(connection(), key(), value()) |> should(eq {:ok, "OK"})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 end

--- a/spec/data_types/mvreg_spec.exs
+++ b/spec/data_types/mvreg_spec.exs
@@ -8,7 +8,7 @@ defmodule Jylis.MVREG.Spec do
   specify "get" do
     db_value = ["#{value()}"]
 
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["MVREG", "GET", key()])
 
@@ -17,11 +17,11 @@ defmodule Jylis.MVREG.Spec do
 
     Jylis.MVREG.get(connection(), key()) |> should(eq {:ok, db_value})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 
   specify "set" do
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["MVREG", "SET", key(), value()])
 
@@ -30,6 +30,6 @@ defmodule Jylis.MVREG.Spec do
 
     Jylis.MVREG.set(connection(), key(), value()) |> should(eq {:ok, "OK"})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 end

--- a/spec/data_types/pncount_spec.exs
+++ b/spec/data_types/pncount_spec.exs
@@ -6,7 +6,7 @@ defmodule Jylis.PNCOUNT.Spec do
   let :value,      do: 50
 
   specify "get" do
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["PNCOUNT", "GET", key()])
 
@@ -15,11 +15,11 @@ defmodule Jylis.PNCOUNT.Spec do
 
     Jylis.PNCOUNT.get(connection(), key()) |> should(eq {:ok, value()})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 
   specify "inc" do
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["PNCOUNT", "INC", key(), value()])
 
@@ -28,11 +28,11 @@ defmodule Jylis.PNCOUNT.Spec do
 
     Jylis.PNCOUNT.inc(connection(), key(), value()) |> should(eq {:ok, "OK"})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 
   specify "dec" do
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["PNCOUNT", "DEC", key(), value()])
 
@@ -41,6 +41,6 @@ defmodule Jylis.PNCOUNT.Spec do
 
     Jylis.PNCOUNT.dec(connection(), key(), value()) |> should(eq {:ok, "OK"})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 end

--- a/spec/data_types/tlog_spec.exs
+++ b/spec/data_types/tlog_spec.exs
@@ -10,7 +10,7 @@ defmodule Jylis.TLOG.Spec do
 
   describe "get" do
     specify do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["TLOG", "GET", key()])
 
@@ -27,11 +27,11 @@ defmodule Jylis.TLOG.Spec do
 
       Jylis.TLOG.get(connection(), key()) |> should(eq {:ok, expected})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     it "passes through errors" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["TLOG", "GET", key()])
 
@@ -40,13 +40,13 @@ defmodule Jylis.TLOG.Spec do
 
       Jylis.TLOG.get(connection(), key()) |> should(eq {:error, nil})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
   end
 
   describe "ins" do
     specify do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["TLOG", "INS", key(), value(), timestamp()])
 
@@ -56,11 +56,11 @@ defmodule Jylis.TLOG.Spec do
       Jylis.TLOG.ins(connection(), key(), value(), timestamp())
       |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     specify "with iso8601 timestamp" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["TLOG", "INS", key(), value(), timestamp()])
 
@@ -70,12 +70,12 @@ defmodule Jylis.TLOG.Spec do
       Jylis.TLOG.ins(connection(), key(), value(), iso8601())
       |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
   end
 
   specify "size" do
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["TLOG", "SIZE", key()])
 
@@ -84,11 +84,11 @@ defmodule Jylis.TLOG.Spec do
 
     Jylis.TLOG.size(connection(), key()) |> should(eq {:ok, 1})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 
   specify "cutoff" do
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["TLOG", "CUTOFF", key()])
 
@@ -97,12 +97,12 @@ defmodule Jylis.TLOG.Spec do
 
     Jylis.TLOG.cutoff(connection(), key()) |> should(eq {:ok, 0})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 
   describe "trimat" do
     specify do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["TLOG", "TRIMAT", key(), timestamp()])
 
@@ -112,11 +112,11 @@ defmodule Jylis.TLOG.Spec do
       Jylis.TLOG.trimat(connection(), key(), timestamp())
       |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     specify "with iso8601 timestamp" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["TLOG", "TRIMAT", key(), timestamp()])
 
@@ -126,12 +126,12 @@ defmodule Jylis.TLOG.Spec do
       Jylis.TLOG.trimat(connection(), key(), iso8601())
       |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
   end
 
   specify "trim" do
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["TLOG", "TRIM", key(), count()])
 
@@ -140,11 +140,11 @@ defmodule Jylis.TLOG.Spec do
 
     Jylis.TLOG.trim(connection(), key(), count()) |> should(eq {:ok, "OK"})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 
   specify "clr" do
-    allow(Jylis).to accept(:query, fn(conn, params) ->
+    allow Jylis |> to(accept :query, fn(conn, params) ->
       conn   |> should(eq connection())
       params |> should(eq ["TLOG", "CLR", key()])
 
@@ -153,6 +153,6 @@ defmodule Jylis.TLOG.Spec do
 
     Jylis.TLOG.clr(connection(), key()) |> should(eq {:ok, "OK"})
 
-    expect(Jylis).to accepted(:query)
+    expect Jylis |> to(accepted :query)
   end
 end

--- a/spec/data_types/treg_spec.exs
+++ b/spec/data_types/treg_spec.exs
@@ -9,7 +9,7 @@ defmodule Jylis.TREG.Spec do
 
   describe "get" do
     specify do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["TREG", "GET", key()])
 
@@ -20,11 +20,11 @@ defmodule Jylis.TREG.Spec do
 
       Jylis.TREG.get(connection(), key()) |> should(eq {:ok, expected})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     it "passes through errors" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["TREG", "GET", key()])
 
@@ -33,13 +33,13 @@ defmodule Jylis.TREG.Spec do
 
       Jylis.TREG.get(connection(), key()) |> should(eq {:error, nil})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
   end
 
   describe "set" do
     specify do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["TREG", "SET", key(), value(), timestamp()])
 
@@ -49,11 +49,11 @@ defmodule Jylis.TREG.Spec do
       Jylis.TREG.set(connection(), key(), value(), timestamp())
       |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     specify "with iso8601 timestamp" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["TREG", "SET", key(), value(), timestamp()])
 
@@ -63,7 +63,7 @@ defmodule Jylis.TREG.Spec do
       Jylis.TREG.set(connection(), key(), value(), iso8601())
       |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
   end
 end

--- a/spec/data_types/ujson_spec.exs
+++ b/spec/data_types/ujson_spec.exs
@@ -13,7 +13,7 @@ defmodule Jylis.UJSON.Spec do
 
   describe "get" do
     specify "with a single key" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["UJSON", "GET", key()])
 
@@ -22,11 +22,11 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.get(connection(), key()) |> should(eq {:ok, values()})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     specify "with multiple keys" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["UJSON", "GET", key(), key2()])
 
@@ -37,11 +37,11 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.get(connection(), keys) |> should(eq {:ok, value()})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     it "passes through errors" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["UJSON", "GET", key()])
 
@@ -50,13 +50,13 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.get(connection(), key()) |> should(eq {:error, nil})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
   end
 
   describe "set" do
     specify "with a single key" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq [
           "UJSON",
@@ -70,11 +70,11 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.set(connection(), key(), values()) |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     specify "with multiple keys" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq [
           "UJSON",
@@ -91,13 +91,13 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.set(connection(), keys, value()) |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
   end
 
   describe "clr" do
     specify "with a single key" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["UJSON", "CLR", key()])
 
@@ -106,11 +106,11 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.clr(connection(), key()) |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     specify "with multiple keys" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["UJSON", "CLR", key(), key2()])
 
@@ -121,13 +121,13 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.clr(connection(), keys) |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
   end
 
   describe "ins" do
     specify "with a single key" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["UJSON", "INS", key(), Poison.encode!(value())])
 
@@ -136,11 +136,11 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.ins(connection(), key(), value()) |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     specify "with multiple keys" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq [
           "UJSON",
@@ -157,13 +157,13 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.ins(connection(), keys, value()) |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
   end
 
   describe "rm" do
     specify "with a single key" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq ["UJSON", "RM", key(), Poison.encode!(value())])
 
@@ -172,11 +172,11 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.rm(connection(), key(), value()) |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
 
     specify "with multiple keys" do
-      allow(Jylis).to accept(:query, fn(conn, params) ->
+      allow Jylis |> to(accept :query, fn(conn, params) ->
         conn   |> should(eq connection())
         params |> should(eq [
           "UJSON",
@@ -193,7 +193,7 @@ defmodule Jylis.UJSON.Spec do
 
       Jylis.UJSON.rm(connection(), keys, value()) |> should(eq {:ok, "OK"})
 
-      expect(Jylis).to accepted(:query)
+      expect Jylis |> to(accepted :query)
     end
   end
 end

--- a/spec/jylis_spec.exs
+++ b/spec/jylis_spec.exs
@@ -8,7 +8,7 @@ defmodule Jylis.Spec do
   describe "start_link" do
     describe "server URI" do
       specify do
-        allow(Redix).to accept(:start_link, fn(opts) ->
+        allow Redix |> to(accept :start_link, fn(opts) ->
           opts[:host] |> should(eq server_host())
           opts[:port] |> should(eq server_port())
 
@@ -17,14 +17,14 @@ defmodule Jylis.Spec do
 
         Jylis.start_link(server_uri()) |> should(eq {:ok, self()})
 
-        expect(Redix).to accepted(:start_link)
+        expect Redix |> to(accepted :start_link)
       end
 
       describe "defaults to port 6379" do
         let :server_uri, do: "jylis://db"
 
         specify do
-          allow(Redix).to accept(:start_link, fn(opts) ->
+          allow Redix |> to(accept :start_link, fn(opts) ->
             opts[:host] |> should(eq "db")
             opts[:port] |> should(eq 6379)
 
@@ -33,7 +33,7 @@ defmodule Jylis.Spec do
 
           Jylis.start_link(server_uri()) |> should(eq {:ok, self()})
 
-          expect(Redix).to accepted(:start_link)
+          expect Redix |> to(accepted :start_link)
         end
       end
 
@@ -41,7 +41,7 @@ defmodule Jylis.Spec do
         let :server_uri, do: "jylis://db:5000"
 
         specify do
-          allow(Redix).to accept(:start_link, fn(opts) ->
+          allow Redix |> to(accept :start_link, fn(opts) ->
             opts[:host] |> should(eq "db")
             opts[:port] |> should(eq 5000)
 
@@ -50,7 +50,7 @@ defmodule Jylis.Spec do
 
           Jylis.start_link(server_uri()) |> should(eq {:ok, self()})
 
-          expect(Redix).to accepted(:start_link)
+          expect Redix |> to(accepted :start_link)
         end
       end
 
@@ -76,7 +76,7 @@ defmodule Jylis.Spec do
     let :connection, do: self()
 
     specify do
-      allow(Redix).to accept(:stop, fn(conn, timeout) ->
+      allow Redix |> to(accept :stop, fn(conn, timeout) ->
         conn    |> should(eq connection())
         timeout |> should(eq :infinity)
 
@@ -85,7 +85,7 @@ defmodule Jylis.Spec do
 
       Jylis.stop(connection()) |> should(eq :ok)
 
-      expect(Redix).to accepted(:stop)
+      expect Redix |> to(accepted :stop)
     end
   end
 
@@ -95,7 +95,7 @@ defmodule Jylis.Spec do
     let :value,      do: 25
 
     specify do
-      allow(Redix).to accept(:command, fn(conn, cmd) ->
+      allow Redix |> to(accept :command, fn(conn, cmd) ->
         conn |> should(eq self())
         cmd  |> should(eq command())
 
@@ -104,7 +104,7 @@ defmodule Jylis.Spec do
 
       Jylis.query(connection(), command()) |> should(eq {:ok, value()})
 
-      expect(Redix).to accepted(:command)
+      expect Redix |> to(accepted :command)
     end
   end
 end


### PR DESCRIPTION
This PR refactors the RSpec-style syntax which is [no longer supported by ESpec](https://github.com/antonmi/espec/issues/272) due to a change in OTP 21. The pipeline operator syntax is used instead.
