### PR TITLE
Allow process name to be registered

### DIFF
--- a/integration/spec/integration_spec.exs
+++ b/integration/spec/integration_spec.exs
@@ -25,6 +25,26 @@ defmodule Integration.Spec do
   finally   do: connection() |> Jylis.stop
   after_all do: stop_server()
 
+  describe "named process" do
+    let :process_name, do: :db
+
+    finally do
+      if Process.whereis(process_name()), do: Jylis.stop(process_name())
+    end
+
+    specify do
+      {:ok, _conn} = Jylis.start_link("jylis://localhost", name: process_name())
+
+      Process.whereis(process_name()) |> should_not(eq nil)
+
+      {:ok, result} =
+        process_name()
+        |> Jylis.query(["MVREG", "GET", "process_name_test"]);
+
+      result |> should(eq [])
+    end
+  end
+
   describe "TREG" do
     specify do
       {:ok, _} = connection() |> Jylis.TREG.set("temperature", 72.1, 1528238308)

--- a/lib/jylis.ex
+++ b/lib/jylis.ex
@@ -10,9 +10,12 @@ defmodule Jylis do
     be `jylis`. The `host` can be a valid hostname, IP address, or domain name.
     The `port` is optional and defaults to `6379`.
 
+  `opts`
+    * `name` - A name to register the process to.
+
   Returns `{:ok, pid}` on success, or `{:error, error}` on failure.
   """
-  def start_link(server_uri) do
+  def start_link(server_uri, opts \\ []) do
     server_uri = URI.parse(server_uri)
 
     case validate_uri(server_uri) do
@@ -21,8 +24,9 @@ defmodule Jylis do
 
       :ok ->
         port = server_uri.port || 6379
+        name = opts |> Keyword.get(:name)
 
-        Redix.start_link(host: server_uri.host, port: port)
+        Redix.start_link([host: server_uri.host, port: port], name: name)
     end
   end
 

--- a/spec/jylis_spec.exs
+++ b/spec/jylis_spec.exs
@@ -8,9 +8,9 @@ defmodule Jylis.Spec do
   describe "start_link" do
     describe "server URI" do
       specify do
-        allow Redix |> to(accept :start_link, fn(opts) ->
-          opts[:host] |> should(eq server_host())
-          opts[:port] |> should(eq server_port())
+        allow Redix |> to(accept :start_link, fn(redix_opts, _other_opts) ->
+          redix_opts[:host] |> should(eq server_host())
+          redix_opts[:port] |> should(eq server_port())
 
           {:ok, self()}
         end)
@@ -24,9 +24,9 @@ defmodule Jylis.Spec do
         let :server_uri, do: "jylis://db"
 
         specify do
-          allow Redix |> to(accept :start_link, fn(opts) ->
-            opts[:host] |> should(eq "db")
-            opts[:port] |> should(eq 6379)
+          allow Redix |> to(accept :start_link, fn(redix_opts, _other_opts) ->
+            redix_opts[:host] |> should(eq "db")
+            redix_opts[:port] |> should(eq 6379)
 
             {:ok, self()}
           end)
@@ -41,9 +41,9 @@ defmodule Jylis.Spec do
         let :server_uri, do: "jylis://db:5000"
 
         specify do
-          allow Redix |> to(accept :start_link, fn(opts) ->
-            opts[:host] |> should(eq "db")
-            opts[:port] |> should(eq 5000)
+          allow Redix |> to(accept :start_link, fn(redix_opts, _other_opts) ->
+            redix_opts[:host] |> should(eq "db")
+            redix_opts[:port] |> should(eq 5000)
 
             {:ok, self()}
           end)
@@ -67,6 +67,25 @@ defmodule Jylis.Spec do
 
         specify do
           Jylis.start_link(server_uri()) |> should(eq {:error, :invalid_host})
+        end
+      end
+
+      describe "with a process name" do
+        specify do
+          process_name = :db
+
+          allow Redix |> to(accept :start_link, fn(redix_opts, other_opts) ->
+          redix_opts[:host] |> should(eq server_host())
+          redix_opts[:port] |> should(eq server_port())
+          other_opts[:name] |> should(eq process_name)
+
+          {:ok, self()}
+        end)
+
+        Jylis.start_link(server_uri(), name: process_name)
+        |> should(eq {:ok, self()})
+
+        expect Redix |> to(accepted :start_link)
         end
       end
     end


### PR DESCRIPTION
This PR adds the `:name` option to `Jylis.start_link`, which allows the process name to be registered.

```elixir
{:ok, _} = Jylis.start_link("jylis://localhost", name: :db)
```